### PR TITLE
A'zo profili sahifasi Github Pages'da ishlashi kerak

### DIFF
--- a/src/ReactRouter/ReactRouter.tsx
+++ b/src/ReactRouter/ReactRouter.tsx
@@ -1,30 +1,24 @@
-
-import Landingpage from '../LandingPage/LandingPage';
-import Roadmap from '../Roadmap/Roadmap';
-import orgChart from '../orgChart/OrgChartTree';
-import Introduction from '../LandingPage/Introduction';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
-import LessonPage from '../Roadmap/components/LessonPage';
-import Screen from '../memberAccounts/Screen';
-
+import Landingpage from "../LandingPage/LandingPage";
+import Roadmap from "../Roadmap/Roadmap";
+import orgChart from "../orgChart/OrgChartTree";
+import Introduction from "../LandingPage/Introduction";
+import { HashRouter, Switch, Route } from "react-router-dom";
+import LessonPage from "../Roadmap/components/LessonPage";
+import Screen from "../memberAccounts/Screen";
 
 function ReactRouter() {
-    return (
-        <Router>
-            <div>
-                <Switch>
-                    <Route path="/" exact component={Landingpage}/>
-                    <Route path="/roadmap"   component={Roadmap} />
-                    <Route path="/organization-tree"  component={orgChart} />
-                    <Route path="/introduction"  component={Introduction} />
-                    <Route path="/lessons/:id"  component={LessonPage} />
-                    <Route path="/member-account/:id" component={Screen} />
-                </Switch>
-            </div>
-        </Router>
-    )
+  return (
+    <HashRouter>
+      <Switch>
+        <Route path="/" exact component={Landingpage} />
+        <Route path="/roadmap" component={Roadmap} />
+        <Route path="/organization-tree" component={orgChart} />
+        <Route path="/introduction" component={Introduction} />
+        <Route path="/lessons/:id" component={LessonPage} />
+        <Route path="/member-account/:id" component={Screen} />
+      </Switch>
+    </HashRouter>
+  );
 }
-
-
 
 export default ReactRouter;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,12 @@
 import ReactDOM from "react-dom";
 //import LandingPage from "./LandingPage/LandingPage";
 import "bootstrap/dist/css/bootstrap.css";
-import ReactRouter from './ReactRouter/ReactRouter';
+import ReactRouter from "./ReactRouter/ReactRouter";
+import React from "react";
 
-ReactDOM.render(<ReactRouter />, document.getElementById("root"));
-
+ReactDOM.render(
+  <React.StrictMode>
+    <ReactRouter />
+  </React.StrictMode>,
+  document.getElementById("root")
+);


### PR DESCRIPTION
A'zo profili localhost'da ishlayapti lekin [Github Pages](https://it-forward.github.io/member-account/0)'da yo'q.

<img width="772" alt="image" src="https://user-images.githubusercontent.com/3971918/206441051-c51b0d6a-e3c9-42ee-a9a0-aec7414e8106.png">

Buning sababi quyida keltirilgan: https://create-react-app.dev/docs/deployment/#notes-on-client-side-routing
StackOverflow'dagi muhokama: https://stackoverflow.com/questions/71984401/react-router-not-working-with-github-pages

Yechim oddiy: `<Router>` komponent o'rniga `<HashRouter>` ishlatish ekan. Lekin endi barcha sahifalar manzilida avval `/#/` keladi. Masalan: http://localhost:3000/#/member-account/0